### PR TITLE
Document the use of the provided scope with Maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Add the dependency simply as follows:
    <groupId>net.biville.florent</groupId>
    <artifactId>neo4j-sproc-compiler</artifactId>
    <version><!-- check last release on https://search.maven.org --></version>
+   <scope>provided</scope>
    <optional>true</optional>
 </dependency>
 ```


### PR DESCRIPTION
This is consistent with the Gradle documentation using the compileOnly
configuration, and avoids the inclusion of neo4j-sproc-compiler and its
dependencies when using the shade plugin to package the procedures jar.