### PR TITLE
[#35] Relocate procedure source files

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
 

--- a/integration-tests/src/test/java/net/biville/florent/sproccompiler/ProcedureTest.java
+++ b/integration-tests/src/test/java/net/biville/florent/sproccompiler/ProcedureTest.java
@@ -15,9 +15,9 @@
  */
 package net.biville.florent.sproccompiler;
 
+import net.biville.florent.sproccompiler.procedures.valid.Procedures;
 import org.junit.Rule;
 import org.junit.Test;
-import test_classes.working_procedures.Procedures;
 
 import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
@@ -32,9 +32,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ProcedureTest
 {
 
-    @Rule
-    public Neo4jRule graphDb = new Neo4jRule().withProcedure( Procedures.class );
+    private static final Class<?> PROCEDURES_CLASS = Procedures.class;
 
+    @Rule
+    public Neo4jRule graphDb = new Neo4jRule().withProcedure( PROCEDURES_CLASS );
+    private String procedureNamespace = PROCEDURES_CLASS.getPackage().getName();
 
     @Test
     public void calls_simplistic_procedure()
@@ -43,7 +45,7 @@ public class ProcedureTest
                 Session session = driver.session() )
         {
 
-            StatementResult result = session.run( "CALL test_classes.working_procedures.theAnswer()" );
+            StatementResult result = session.run( "CALL " + procedureNamespace + ".theAnswer()" );
 
             assertThat( result.single().get( "value" ).asLong() ).isEqualTo( 42L );
         }
@@ -56,17 +58,17 @@ public class ProcedureTest
                 Session session = driver.session() )
         {
 
-            session.run( "CALL test_classes.working_procedures.simpleInput00()" );
-            session.run( "CALL test_classes.working_procedures.simpleInput01('string')" );
-            session.run( "CALL test_classes.working_procedures.simpleInput02(42)" );
-            session.run( "CALL test_classes.working_procedures.simpleInput03(42)" );
-            session.run( "CALL test_classes.working_procedures.simpleInput04(4.2)" );
-            session.run( "CALL test_classes.working_procedures.simpleInput05(true)" );
-            session.run( "CALL test_classes.working_procedures.simpleInput06(false)" );
-            session.run( "CALL test_classes.working_procedures.simpleInput07({foo:'bar'})" );
-            session.run( "MATCH (n)            CALL test_classes.working_procedures.simpleInput08(n) RETURN n" );
-            session.run( "MATCH p=(()-[r]->()) CALL test_classes.working_procedures.simpleInput09(p) RETURN p" );
-            session.run( "MATCH ()-[r]->()     CALL test_classes.working_procedures.simpleInput10(r) RETURN r" );
+            session.run( "CALL " + procedureNamespace + ".simpleInput00()" );
+            session.run( "CALL " + procedureNamespace + ".simpleInput01('string')" );
+            session.run( "CALL " + procedureNamespace + ".simpleInput02(42)" );
+            session.run( "CALL " + procedureNamespace + ".simpleInput03(42)" );
+            session.run( "CALL " + procedureNamespace + ".simpleInput04(4.2)" );
+            session.run( "CALL " + procedureNamespace + ".simpleInput05(true)" );
+            session.run( "CALL " + procedureNamespace + ".simpleInput06(false)" );
+            session.run( "CALL " + procedureNamespace + ".simpleInput07({foo:'bar'})" );
+            session.run( "MATCH (n)            CALL " + procedureNamespace + ".simpleInput08(n) RETURN n" );
+            session.run( "MATCH p=(()-[r]->()) CALL " + procedureNamespace + ".simpleInput09(p) RETURN p" );
+            session.run( "MATCH ()-[r]->()     CALL " + procedureNamespace + ".simpleInput10(r) RETURN r" );
         }
     }
 
@@ -77,21 +79,15 @@ public class ProcedureTest
                 Session session = driver.session() )
         {
 
-            assertThat( session.run( "CALL test_classes.working_procedures.simpleInput11('string')" ).single() )
+            assertThat( session.run( "CALL " + procedureNamespace + ".simpleInput11('string')" ).single() ).isNotNull();
+            assertThat( session.run( "CALL " + procedureNamespace + ".simpleInput12(42)" ).single() ).isNotNull();
+            assertThat( session.run( "CALL " + procedureNamespace + ".simpleInput13(42)" ).single() ).isNotNull();
+            assertThat( session.run( "CALL " + procedureNamespace + ".simpleInput14(4.2)" ).single() ).isNotNull();
+            assertThat( session.run( "CALL " + procedureNamespace + ".simpleInput15(true)" ).single() ).isNotNull();
+            assertThat( session.run( "CALL " + procedureNamespace + ".simpleInput16(false)" ).single() ).isNotNull();
+            assertThat( session.run( "CALL " + procedureNamespace + ".simpleInput17({foo:'bar'})" ).single() )
                     .isNotNull();
-            assertThat( session.run( "CALL test_classes.working_procedures.simpleInput12(42)" ).single() ).isNotNull();
-            assertThat( session.run( "CALL test_classes.working_procedures.simpleInput13(42)" ).single() ).isNotNull();
-            assertThat( session.run( "CALL test_classes.working_procedures.simpleInput14(4.2)" ).single() ).isNotNull();
-            assertThat( session.run( "CALL test_classes.working_procedures.simpleInput15(true)" ).single() )
-                    .isNotNull();
-            assertThat( session.run( "CALL test_classes.working_procedures.simpleInput16(false)" ).single() )
-                    .isNotNull();
-            assertThat( session.run( "CALL test_classes.working_procedures.simpleInput17({foo:'bar'})" ).single() )
-                    .isNotNull();
-//            assertThat(session.run("MATCH (n)            CALL test_classes.working_procedures.simpleInput18(n) YIELD field01 RETURN *").single()).isNotNull();
-//            assertThat(session.run("MATCH p=(()-[r]->()) CALL test_classes.working_procedures.simpleInput19(p) YIELD field01 RETURN *").single()).isNotNull();
-//            assertThat(session.run("MATCH ()-[r]->()     CALL test_classes.working_procedures.simpleInput20(r) YIELD field01 RETURN *").single()).isNotNull();
-            assertThat( session.run( "CALL test_classes.working_procedures.simpleInput21()" ).single() ).isNotNull();
+            assertThat( session.run( "CALL " + procedureNamespace + ".simpleInput21()" ).single() ).isNotNull();
         }
 
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>net.biville.florent</groupId>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -45,6 +46,12 @@
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
@@ -62,24 +69,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.10</version>
-                <executions>
-                    <execution>
-                        <id>add-custom-test-sources</id>
-                        <goals>
-                            <goal>add-test-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>${project.basedir}/src/test/resources/test_classes/working_procedures</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.0.1</version>
                 <executions>
@@ -89,7 +78,7 @@
                         </goals>
                         <configuration>
                             <includes>
-                                <include>**/working_procedures/**</include>
+                                <include>net/biville/florent/sproccompiler/procedures/valid/**/*</include>
                             </includes>
                         </configuration>
                     </execution>

--- a/processor/src/main/java/net/biville/florent/sproccompiler/StoredProcedureProcessor.java
+++ b/processor/src/main/java/net/biville/florent/sproccompiler/StoredProcedureProcessor.java
@@ -83,8 +83,8 @@ public class StoredProcedureProcessor extends AbstractProcessor
 
         visitedProcedures.clear();
         messagePrinter = new MessagePrinter( processingEnv.getMessager() );
-        storedProcedureVisitor = new StoredProcedureVisitor( typeUtils, elementUtils, processingEnv.getOptions().containsKey(
-                IGNORE_CONTEXT_WARNINGS ) );
+        storedProcedureVisitor = new StoredProcedureVisitor( typeUtils, elementUtils,
+                processingEnv.getOptions().containsKey( IGNORE_CONTEXT_WARNINGS ) );
         duplicateProcedure = new DuplicatedStoredProcedureValidator( typeUtils, elementUtils );
     }
 

--- a/processor/src/test/java/net/biville/florent/sproccompiler/StoredProcedureProcessorTest.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/StoredProcedureProcessorTest.java
@@ -25,7 +25,6 @@ import javax.annotation.processing.Processor;
 import javax.tools.JavaFileObject;
 
 import static com.google.common.truth.Truth.assert_;
-import static com.google.testing.compile.JavaFileObjects.forResource;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 import static java.util.Arrays.asList;
@@ -41,7 +40,8 @@ public class StoredProcedureProcessorTest
     @Test
     public void fails_if_parameters_are_not_properly_annotated()
     {
-        JavaFileObject sproc = JavaFileObjectUtils.resource( "missing_name/MissingNameSproc.java" );
+        JavaFileObject sproc =
+                JavaFileObjectUtils.INSTANCE.procedureSource( "invalid/missing_name/MissingNameSproc.java" );
 
         UnsuccessfulCompilationClause compilation =
                 assert_().about( javaSource() ).that( sproc ).processedWith( processor ).failsToCompile()
@@ -57,7 +57,8 @@ public class StoredProcedureProcessorTest
     @Test
     public void fails_if_return_type_is_not_stream()
     {
-        JavaFileObject sproc = JavaFileObjectUtils.resource( "bad_return_type/BadReturnTypeSproc.java" );
+        JavaFileObject sproc =
+                JavaFileObjectUtils.INSTANCE.procedureSource( "invalid/bad_return_type/BadReturnTypeSproc.java" );
 
         assert_().about( javaSource() ).that( sproc ).processedWith( processor ).failsToCompile().withErrorCount( 1 )
                 .withErrorContaining( "Return type of BadReturnTypeSproc#niceSproc must be java.util.stream.Stream" )
@@ -67,11 +68,12 @@ public class StoredProcedureProcessorTest
     @Test
     public void fails_if_record_type_has_nonpublic_fields()
     {
-        JavaFileObject record = JavaFileObjectUtils.resource( "bad_record_type/BadRecord.java" );
+        JavaFileObject record =
+                JavaFileObjectUtils.INSTANCE.procedureSource( "invalid/bad_record_type/BadRecord.java" );
 
-        UnsuccessfulCompilationClause compilation = assert_().about( javaSources() )
-                .that( asList( forResource( "test_classes/bad_record_type/BadRecordTypeSproc.java" ), record ) )
-                .processedWith( processor ).failsToCompile().withErrorCount( 2 );
+        UnsuccessfulCompilationClause compilation = assert_().about( javaSources() ).that( asList(
+                JavaFileObjectUtils.INSTANCE.procedureSource( "invalid/bad_record_type/BadRecordTypeSproc.java" ),
+                record ) ).processedWith( processor ).failsToCompile().withErrorCount( 2 );
 
         compilation.withErrorContaining( "Record definition error: field BadRecord#label must be public" ).in( record )
                 .onLine( 22 );
@@ -83,7 +85,8 @@ public class StoredProcedureProcessorTest
     @Test
     public void fails_if_procedure_primitive_input_type_is_not_supported()
     {
-        JavaFileObject sproc = JavaFileObjectUtils.resource( "bad_proc_input_type/BadPrimitiveInputSproc.java" );
+        JavaFileObject sproc = JavaFileObjectUtils.INSTANCE
+                .procedureSource( "invalid/bad_proc_input_type/BadPrimitiveInputSproc.java" );
 
         assert_().about( javaSource() ).that( sproc ).processedWith( processor ).failsToCompile().withErrorCount( 1 )
                 .withErrorContaining(
@@ -94,7 +97,8 @@ public class StoredProcedureProcessorTest
     @Test
     public void fails_if_procedure_generic_input_type_is_not_supported()
     {
-        JavaFileObject sproc = JavaFileObjectUtils.resource( "bad_proc_input_type/BadGenericInputSproc.java" );
+        JavaFileObject sproc =
+                JavaFileObjectUtils.INSTANCE.procedureSource( "invalid/bad_proc_input_type/BadGenericInputSproc.java" );
 
         UnsuccessfulCompilationClause compilation =
                 assert_().about( javaSource() ).that( sproc ).processedWith( processor ).failsToCompile()
@@ -116,10 +120,11 @@ public class StoredProcedureProcessorTest
     @Test
     public void fails_if_procedure_primitive_record_field_type_is_not_supported()
     {
-        JavaFileObject record = JavaFileObjectUtils.resource( "bad_record_field_type/BadRecordSimpleFieldType.java" );
+        JavaFileObject record = JavaFileObjectUtils.INSTANCE
+                .procedureSource( "invalid/bad_record_field_type/BadRecordSimpleFieldType.java" );
 
-        assert_().about( javaSources() ).that( asList(
-                JavaFileObjectUtils.resource( "bad_record_field_type/BadRecordSimpleFieldTypeSproc.java" ), record ) )
+        assert_().about( javaSources() ).that( asList( JavaFileObjectUtils.INSTANCE
+                .procedureSource( "invalid/bad_record_field_type/BadRecordSimpleFieldTypeSproc.java" ), record ) )
                 .processedWith( processor ).failsToCompile().withErrorCount( 1 ).withErrorContaining(
                 "Record definition error: type of field BadRecordSimpleFieldType#wrongType is not supported" )
                 .in( record ).onLine( 25 );
@@ -128,11 +133,13 @@ public class StoredProcedureProcessorTest
     @Test
     public void fails_if_procedure_generic_record_field_type_is_not_supported()
     {
-        JavaFileObject record = JavaFileObjectUtils.resource( "bad_record_field_type/BadRecordGenericFieldType.java" );
+        JavaFileObject record = JavaFileObjectUtils.INSTANCE
+                .procedureSource( "invalid/bad_record_field_type/BadRecordGenericFieldType.java" );
 
         UnsuccessfulCompilationClause compilation = assert_().about( javaSources() ).that( asList(
-                JavaFileObjectUtils.resource( "bad_record_field_type/BadRecordGenericFieldTypeSproc.java" ), record ) )
-                .processedWith( processor ).failsToCompile().withErrorCount( 3 );
+                JavaFileObjectUtils.INSTANCE
+                        .procedureSource( "invalid/bad_record_field_type/BadRecordGenericFieldTypeSproc.java" ),
+                record ) ).processedWith( processor ).failsToCompile().withErrorCount( 3 );
 
         compilation.withErrorContaining(
                 "Record definition error: type of field BadRecordGenericFieldType#wrongType1 is not supported" )
@@ -148,24 +155,26 @@ public class StoredProcedureProcessorTest
     @Test
     public void fails_if_duplicate_procedures_are_declared()
     {
-        JavaFileObject firstDuplicate = JavaFileObjectUtils.resource( "duplicated/Sproc1.java" );
-        JavaFileObject secondDuplicate = JavaFileObjectUtils.resource( "duplicated/Sproc2.java" );
+        JavaFileObject firstDuplicate =
+                JavaFileObjectUtils.INSTANCE.procedureSource( "invalid/duplicated/Sproc1.java" );
+        JavaFileObject secondDuplicate =
+                JavaFileObjectUtils.INSTANCE.procedureSource( "invalid/duplicated/Sproc2.java" );
 
         assert_().about( javaSources() ).that( asList( firstDuplicate, secondDuplicate ) ).processedWith( processor )
                 .failsToCompile().withErrorCount( 2 ).withErrorContaining(
-                "Procedure name <test_classes.duplicated#foobar> is already defined 2 times. " +
+                "Procedure name <net.biville.florent.sproccompiler.procedures.invalid.duplicated#foobar> is already defined 2 times. " +
                         "It should be defined only once!" );
     }
 
     @Test
     public void fails_if_procedure_class_has_no_public_no_arg_constructor()
     {
-        JavaFileObject procedure =
-                JavaFileObjectUtils.resource( "missing_constructor/MissingConstructorProcedure.java" );
+        JavaFileObject procedure = JavaFileObjectUtils.INSTANCE
+                .procedureSource( "invalid/missing_constructor/MissingConstructorProcedure.java" );
 
         assert_().about( javaSource() ).that( procedure ).processedWith( processor ).failsToCompile()
                 .withErrorCount( 1 ).withErrorContaining(
-                "Procedure class test_classes.duplicated.MissingConstructorProcedure should contain a public no-arg constructor, none found." )
+                "Procedure class net.biville.florent.sproccompiler.procedures.invalid.missing_constructor.MissingConstructorProcedure should contain a public no-arg constructor, none found." )
                 .in( procedure ).onLine( 20 );
     }
 
@@ -173,16 +182,17 @@ public class StoredProcedureProcessorTest
     public void succeeds_to_process_valid_stored_procedures()
     {
         assert_().about( javaSources() )
-                .that( asList( JavaFileObjectUtils.resource( "working_procedures/Procedures.java" ),
-                        JavaFileObjectUtils.resource( "working_procedures/Records.java" ) ) ).processedWith( processor )
-                .compilesWithoutError();
+                .that( asList( JavaFileObjectUtils.INSTANCE.procedureSource( "valid/Procedures.java" ),
+                        JavaFileObjectUtils.INSTANCE.procedureSource( "valid/Records.java" ) ) )
+                .processedWith( processor ).compilesWithoutError();
 
     }
 
     @Test
     public void fails_if_context_injected_fields_have_wrong_modifiers()
     {
-        JavaFileObject sproc = JavaFileObjectUtils.resource( "bad_context_field/BadContextSproc.java" );
+        JavaFileObject sproc =
+                JavaFileObjectUtils.INSTANCE.procedureSource( "invalid/bad_context_field/BadContextSproc.java" );
 
         UnsuccessfulCompilationClause unsuccessfulCompilationClause =
                 assert_().about( javaSource() ).that( sproc ).processedWith( processor ).failsToCompile()
@@ -207,12 +217,12 @@ public class StoredProcedureProcessorTest
     @Test
     public void emits_warnings_if_context_injected_field_types_are_unsupported()
     {
-        JavaFileObject sproc = JavaFileObjectUtils.resource( "bad_context_field/BadContextTypeSproc.java" );
+        JavaFileObject sproc =
+                JavaFileObjectUtils.INSTANCE.procedureSource( "invalid/bad_context_field/BadContextTypeSproc.java" );
 
         assert_().about( javaSource() ).that( sproc ).processedWith( processor ).compilesWithoutError()
-                .withWarningCount( 2 )
-                .withWarningContaining(
-                        "@org.neo4j.procedure.Context usage warning: found type: <org.neo4j.kernel.internal.GraphDatabaseAPI>, expected one of: <org.neo4j.graphdb.GraphDatabaseService>, <org.neo4j.logging.Log>" )
+                .withWarningCount( 2 ).withWarningContaining(
+                "@org.neo4j.procedure.Context usage warning: found type: <org.neo4j.kernel.internal.GraphDatabaseAPI>, expected one of: <org.neo4j.graphdb.GraphDatabaseService>, <org.neo4j.logging.Log>" )
                 .in( sproc ).onLine( 26 );
 
 
@@ -221,10 +231,10 @@ public class StoredProcedureProcessorTest
     @Test
     public void does_not_emit_warnings_if_context_injected_field_types_are_unsupported_when_context_warnings_disabled()
     {
-        JavaFileObject sproc = JavaFileObjectUtils.resource( "bad_context_field/BadContextTypeSproc.java" );
+        JavaFileObject sproc =
+                JavaFileObjectUtils.INSTANCE.procedureSource( "invalid/bad_context_field/BadContextTypeSproc.java" );
 
-        assert_().about( javaSource() ).that( sproc )
-                .withCompilerOptions( "-AIgnoreContextWarnings" )
+        assert_().about( javaSource() ).that( sproc ).withCompilerOptions( "-AIgnoreContextWarnings" )
                 .processedWith( processor ).compilesWithoutError().withWarningCount( 1 );
 
 

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_context_field/BadContextSproc.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_context_field/BadContextSproc.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package test_classes.bad_context_field;
+package net.biville.florent.sproccompiler.procedures.invalid.bad_context_field;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.procedure.Context;

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_context_field/BadContextTypeSproc.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_context_field/BadContextTypeSproc.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package test_classes.bad_context_field;
+package net.biville.florent.sproccompiler.procedures.invalid.bad_context_field;
 
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.procedure.Context;

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_proc_input_type/BadGenericInputSproc.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_proc_input_type/BadGenericInputSproc.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package test_classes.bad_proc_input_type;
+package net.biville.florent.sproccompiler.procedures.invalid.bad_proc_input_type;
 
 import java.util.List;
 import java.util.Map;

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_proc_input_type/BadPrimitiveInputSproc.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_proc_input_type/BadPrimitiveInputSproc.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package test_classes.bad_proc_input_type;
+package net.biville.florent.sproccompiler.procedures.invalid.bad_proc_input_type;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_record_field_type/BadRecordGenericFieldType.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_record_field_type/BadRecordGenericFieldType.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package test_classes.bad_record_field_type;
+package net.biville.florent.sproccompiler.procedures.invalid.bad_record_field_type;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_record_field_type/BadRecordGenericFieldTypeSproc.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_record_field_type/BadRecordGenericFieldTypeSproc.java
@@ -13,28 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package test_classes.missing_name;
+package net.biville.florent.sproccompiler.procedures.invalid.bad_record_field_type;
 
 import java.util.stream.Stream;
 
-import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Procedure;
 
-public class MissingNameSproc
+public class BadRecordGenericFieldTypeSproc
 {
 
-    @Context
-    public GraphDatabaseService db;
-
     @Procedure
-    public Stream<GoodRecord> niceSproc( String parameter, String otherParam )
+    public Stream<BadRecordGenericFieldType> doSomething()
     {
         return Stream.empty();
-    }
-
-    public static class GoodRecord
-    {
-        public long age;
     }
 }

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_record_field_type/BadRecordSimpleFieldType.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_record_field_type/BadRecordSimpleFieldType.java
@@ -13,27 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package test_classes.bad_return_type;
+package net.biville.florent.sproccompiler.procedures.invalid.bad_record_field_type;
 
-import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.procedure.Context;
-import org.neo4j.procedure.Name;
-import org.neo4j.procedure.Procedure;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.Relationship;
 
-public class BadReturnTypeSproc
+public class BadRecordSimpleFieldType
 {
 
-    @Context
-    public GraphDatabaseService db;
-
-    @Procedure
-    public Long niceSproc( @Name( "foo" ) String parameter )
-    {
-        return 42L;
-    }
-
-    @Procedure
-    public void niceSproc2( @Name( "foo" ) String parameter )
-    {
-    }
+    public Integer wrongType;
+    public String okType1;
+    public Long okType2;
+    public long okType3;
+    public Double okType4;
+    public double okType5;
+    public Number okType6;
+    public Boolean okType7;
+    public boolean okType8;
+    public Path okType9;
+    public Node okType10;
+    public Relationship okType11;
+    public Object okType12;
 }

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_record_field_type/BadRecordSimpleFieldTypeSproc.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_record_field_type/BadRecordSimpleFieldTypeSproc.java
@@ -13,26 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package test_classes.bad_record_field_type;
+package net.biville.florent.sproccompiler.procedures.invalid.bad_record_field_type;
 
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.Path;
-import org.neo4j.graphdb.Relationship;
+import java.util.stream.Stream;
 
-public class BadRecordSimpleFieldType
+import org.neo4j.procedure.Procedure;
+
+public class BadRecordSimpleFieldTypeSproc
 {
 
-    public Integer wrongType;
-    public String okType1;
-    public Long okType2;
-    public long okType3;
-    public Double okType4;
-    public double okType5;
-    public Number okType6;
-    public Boolean okType7;
-    public boolean okType8;
-    public Path okType9;
-    public Node okType10;
-    public Relationship okType11;
-    public Object okType12;
+    @Procedure
+    public Stream<BadRecordSimpleFieldType> doSomething()
+    {
+        return Stream.empty();
+    }
 }

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_record_type/BadRecord.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_record_type/BadRecord.java
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package test_classes.bad_record_field_type;
+package net.biville.florent.sproccompiler.procedures.invalid.bad_record_type;
 
-import java.util.stream.Stream;
-
-import org.neo4j.procedure.Procedure;
-
-public class BadRecordGenericFieldTypeSproc
+public class BadRecord
 {
 
-    @Procedure
-    public Stream<BadRecordGenericFieldType> doSomething()
+    private static final int DEFAULT_AGE = 42;
+    private final String label; /* nonstatic fields should be public */
+    private final int age;
+
+    public BadRecord( String label, int age )
     {
-        return Stream.empty();
+        this.label = label;
+        this.age = age < 0 ? DEFAULT_AGE : age;
     }
 }

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_record_type/BadRecordTypeSproc.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_record_type/BadRecordTypeSproc.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package test_classes.bad_record_type;
+package net.biville.florent.sproccompiler.procedures.invalid.bad_record_type;
 
 import java.util.stream.Stream;
 

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_return_type/BadReturnTypeSproc.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/bad_return_type/BadReturnTypeSproc.java
@@ -13,22 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package test_classes.duplicated;
+package net.biville.florent.sproccompiler.procedures.invalid.bad_return_type;
 
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
-public class Sproc1
+public class BadReturnTypeSproc
 {
 
-    @Procedure
-    public void foobar()
-    {
+    @Context
+    public GraphDatabaseService db;
 
+    @Procedure
+    public Long niceSproc( @Name( "foo" ) String parameter )
+    {
+        return 42L;
     }
 
     @Procedure
-    public void foobarbaz()
+    public void niceSproc2( @Name( "foo" ) String parameter )
     {
-
     }
 }

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/duplicated/Sproc1.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/duplicated/Sproc1.java
@@ -13,18 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package test_classes.bad_record_type;
+package net.biville.florent.sproccompiler.procedures.invalid.duplicated;
 
-public class BadRecord
+import org.neo4j.procedure.Procedure;
+
+public class Sproc1
 {
 
-    private static final int DEFAULT_AGE = 42;
-    private final String label; /* nonstatic fields should be public */
-    private final int age;
-
-    public BadRecord( String label, int age )
+    @Procedure
+    public void foobar()
     {
-        this.label = label;
-        this.age = age < 0 ? DEFAULT_AGE : age;
+
+    }
+
+    @Procedure
+    public void foobarbaz()
+    {
+
     }
 }

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/duplicated/Sproc2.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/duplicated/Sproc2.java
@@ -13,22 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package test_classes.duplicated;
+package net.biville.florent.sproccompiler.procedures.invalid.duplicated;
 
 import org.neo4j.procedure.Procedure;
 
-public class MissingConstructorProcedure
+public class Sproc2
 {
-    // should be no-arg
-    public MissingConstructorProcedure( String oopsAParameter )
-    {
-    }
-
-    // should be public
-    private MissingConstructorProcedure()
-    {
-
-    }
 
     @Procedure
     public void foobar()

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/missing_constructor/MissingConstructorProcedure.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/missing_constructor/MissingConstructorProcedure.java
@@ -13,12 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package test_classes.duplicated;
+package net.biville.florent.sproccompiler.procedures.invalid.missing_constructor;
 
 import org.neo4j.procedure.Procedure;
 
-public class Sproc2
+public class MissingConstructorProcedure
 {
+    // should be no-arg
+    public MissingConstructorProcedure( String oopsAParameter )
+    {
+    }
+
+    // should be public
+    private MissingConstructorProcedure()
+    {
+
+    }
 
     @Procedure
     public void foobar()

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/missing_name/MissingNameSproc.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/invalid/missing_name/MissingNameSproc.java
@@ -13,18 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package test_classes.bad_record_field_type;
+package net.biville.florent.sproccompiler.procedures.invalid.missing_name;
 
 import java.util.stream.Stream;
 
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Procedure;
 
-public class BadRecordSimpleFieldTypeSproc
+public class MissingNameSproc
 {
 
+    @Context
+    public GraphDatabaseService db;
+
     @Procedure
-    public Stream<BadRecordSimpleFieldType> doSomething()
+    public Stream<GoodRecord> niceSproc( String parameter, String otherParam )
     {
         return Stream.empty();
+    }
+
+    public static class GoodRecord
+    {
+        public long age;
     }
 }

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/valid/Procedures.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/valid/Procedures.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package test_classes.working_procedures;
+package net.biville.florent.sproccompiler.procedures.valid;
 
 import java.util.List;
 import java.util.Map;

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/valid/Records.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/valid/Records.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package test_classes.working_procedures;
+package net.biville.florent.sproccompiler.procedures.valid;
 
 import java.util.List;
 import java.util.Map;

--- a/processor/src/test/java/net/biville/florent/sproccompiler/testutils/JavaFileObjectUtils.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/testutils/JavaFileObjectUtils.java
@@ -16,21 +16,58 @@
 package net.biville.florent.sproccompiler.testutils;
 
 import com.google.testing.compile.JavaFileObjects;
-import net.biville.florent.sproccompiler.StoredProcedureProcessorTest;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Properties;
 import javax.tools.JavaFileObject;
 
-public class JavaFileObjectUtils
-{
+import static org.assertj.core.api.Assertions.assertThat;
 
-    public static JavaFileObject resource( String url )
+public enum JavaFileObjectUtils
+{
+    INSTANCE;
+
+    private final String baseDirectory;
+
+    JavaFileObjectUtils()
     {
-        return JavaFileObjects.forResource( at( url ) );
+        Properties properties = loadProperties( "/procedures.properties" );
+        baseDirectory = properties.getProperty( "base_directory" );
+        assertThat( new File( baseDirectory ) ).exists();
     }
 
-    private static URL at( String resource )
+    public JavaFileObject procedureSource( String relativePath )
     {
-        return StoredProcedureProcessorTest.class.getResource( String.format( "/test_classes/%s", resource ) );
+        return JavaFileObjects.forResource( resolveUrl( relativePath ) );
+    }
+
+    private final Properties loadProperties( String name )
+    {
+        try ( InputStream paths = this.getClass().getResourceAsStream( name ) )
+        {
+            Properties properties = new Properties();
+            properties.load( paths );
+            return properties;
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+
+    private URL resolveUrl( String relativePath )
+    {
+        try
+        {
+            return new File( baseDirectory, relativePath ).toURI().toURL();
+        }
+        catch ( MalformedURLException e )
+        {
+            throw new RuntimeException( e.getMessage(), e );
+        }
     }
 }

--- a/processor/src/test/java/net/biville/florent/sproccompiler/visitors/FieldVisitorTest.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/visitors/FieldVisitorTest.java
@@ -44,8 +44,7 @@ public class FieldVisitorTest
     public void prepare()
     {
         elementTestUtils = new ElementTestUtils( compilationRule );
-        fieldVisitor = new FieldVisitor( compilationRule.getTypes(), compilationRule.getElements(),
-                false );
+        fieldVisitor = new FieldVisitor( compilationRule.getTypes(), compilationRule.getElements(), false );
     }
 
     @Test

--- a/processor/src/test/resources/procedures.properties
+++ b/processor/src/test/resources/procedures.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2016-2016 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+base_directory=${project.basedir}/src/test/java/net/biville/florent/sproccompiler/procedures/

--- a/processor/src/test/resources/test_classes/working_procedures/README.md
+++ b/processor/src/test/resources/test_classes/working_procedures/README.md
@@ -1,7 +1,0 @@
-# `test_classes.working_procedures` package
-
-The procedures and records defined here serve two purposes:
-
- 1. they represent valid cases and (must) pass unit tests
- 1. they, and only they, are included in the test JAR later used
- for integration tests


### PR DESCRIPTION
Procedure source file for the processor unit tests are now
in the standard test source file location, thus being considered
as plain old Java files.

test-jar packaging has been therefore simplified and filters out
invalid procedures.