### PR TITLE
Allow CSV export of procedures/user functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <neo4j.version>3.1.0-M10</neo4j.version>
+        <neo4j.version>3.1.0-M13-beta3</neo4j.version>
     </properties>
 
     <modules>

--- a/processor/src/main/java/net/biville/florent/sproccompiler/CsvProcessor.java
+++ b/processor/src/main/java/net/biville/florent/sproccompiler/CsvProcessor.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2016-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.biville.florent.sproccompiler;
+
+import com.google.auto.service.AutoService;
+import net.biville.florent.sproccompiler.io.CsvWriter;
+import net.biville.florent.sproccompiler.visitors.ExecutableElementVisitor;
+import org.neo4j.procedure.*;
+
+import javax.annotation.processing.*;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.*;
+import javax.lang.model.util.Elements;
+import java.io.File;
+import java.io.FileWriter;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Arrays.asList;
+
+@AutoService( Processor.class )
+public class CsvProcessor extends AbstractProcessor {
+
+    private static final String DOCUMENTATION_ROOT_PATH = "GeneratedDocumentationPath";
+    private final Map<PackageElement, Collection<ExecutableElement>> apocCatalog = new HashMap<>();
+    private Elements elementUtils;
+    private ElementVisitor<ExecutableElement, Void> methodVisitor;
+    private Optional<Path> rootPath;
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return new HashSet<>(asList(Procedure.class.getName(), UserFunction.class.getName()));
+    }
+
+    @Override
+    public Set<String> getSupportedOptions() {
+        return Collections.singleton(DOCUMENTATION_ROOT_PATH);
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.RELEASE_8;
+    }
+
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv) {
+        apocCatalog.clear();
+        elementUtils = processingEnv.getElementUtils();
+        methodVisitor = new ExecutableElementVisitor(processingEnv.getMessager());
+        rootPath = Optional.ofNullable(processingEnv.getOptions().getOrDefault(DOCUMENTATION_ROOT_PATH, null))
+                        .map(Paths::get);
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        rootPath.ifPresent((root) -> {
+            if (!roundEnv.processingOver()) {
+                roundEnv.getElementsAnnotatedWith(Procedure.class).forEach(this::index);
+                roundEnv.getElementsAnnotatedWith(UserFunction.class).forEach(this::index);
+
+            } else {
+                generateDocumentation(root);
+            }
+        });
+        
+
+        return false;
+    }
+
+    private void index(Element el) {
+        ExecutableElement method = methodVisitor.visit(el);
+        apocCatalog.computeIfAbsent(elementUtils.getPackageOf(method), (k) -> new ArrayList<>()).add(method);
+    }
+
+    private void generateDocumentation(Path root) {
+        apocCatalog.entrySet().forEach(kv -> {
+            generatePackageDocumentation(root, kv);
+        });
+    }
+
+    private void generatePackageDocumentation(Path root, Map.Entry<PackageElement, Collection<ExecutableElement>> kv) {
+        PackageElement packageElement = kv.getKey();
+        File file = new File(root.toFile(), packageElement.getSimpleName() + ".csv");
+
+        List<String> header = asList("name", "description", "execution mode", "location", "deprecated by");
+        try (FileWriter resource = new FileWriter(file);
+             CsvWriter writer = new CsvWriter(header, resource)) {
+
+            writer.write(kv.getValue().stream(), this::generateCallableDocumentation);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    private Stream<String> generateCallableDocumentation(ExecutableElement method) {
+        return Stream.of(
+                name(method),
+                description(method),
+                executionMode(method),
+                location(method),
+                deprecatedBy(method)
+        );
+    }
+
+    private String name(ExecutableElement method) {
+        return String.format("%s(%s)", callableName(method), parameters(method));
+    }
+
+    private String description(ExecutableElement method) {
+        Description description = method.getAnnotation(Description.class);
+        if (description == null) {
+            return "";
+        }
+        return description.value();
+    }
+
+    private String executionMode(ExecutableElement method) {
+        PerformsWrites performsWrites = method.getAnnotation(PerformsWrites.class);
+        if (performsWrites != null) {
+            return "PERFORMS_WRITE";
+        }
+        Procedure procedure = method.getAnnotation(Procedure.class);
+        if (procedure != null) {
+            return procedure.mode().name();
+        }
+        return "N/A";
+    }
+
+    private String location(ExecutableElement method) {
+        return String.format("%s.%s",
+                elementUtils.getPackageOf(method).getQualifiedName(),
+                method.getEnclosingElement().getSimpleName());
+    }
+
+    private String deprecatedBy(ExecutableElement method) {
+        UserFunction function = method.getAnnotation(UserFunction.class);
+        if (function != null) {
+            String deprecatedBy = function.deprecatedBy();
+            return deprecatedBy.isEmpty() ? "N/A" : deprecatedBy;
+        }
+        String deprecatedBy = method.getAnnotation(Procedure.class).deprecatedBy();
+        return deprecatedBy.isEmpty() ? "N/A" : deprecatedBy;
+    }
+
+    private String callableName(ExecutableElement method) {
+        Supplier<String> defaultName = () -> elementUtils.getPackageOf(method).getQualifiedName() + "." + method.getSimpleName();
+        UserFunction function = method.getAnnotation(UserFunction.class);
+        if (function != null) {
+            return UserFunctionProcessor.getCustomName(function).orElseGet(defaultName);
+        }
+        Procedure procedure = method.getAnnotation(Procedure.class);
+        return ProcedureProcessor.getCustomName(procedure).orElseGet(defaultName);
+    }
+
+    private String parameters(ExecutableElement method) {
+        return method.getParameters().stream()
+                .map(this::parameterSignature)
+                .collect(Collectors.joining(","));
+    }
+
+    private String parameterSignature(VariableElement param) {
+        return param.asType().toString().replace("java.lang.", "") + " " + param.getAnnotation(org.neo4j.procedure.Name.class).value();
+    }
+
+}

--- a/processor/src/main/java/net/biville/florent/sproccompiler/io/CsvWriter.java
+++ b/processor/src/main/java/net/biville/florent/sproccompiler/io/CsvWriter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.biville.florent.sproccompiler.io;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.joining;
+
+public class CsvWriter implements AutoCloseable {
+
+    private final Collection<String> header;
+    private final Writer writer;
+    private final String separator;
+
+    public CsvWriter(Collection<String> header, Writer writer) {
+        this.header = header;
+        this.writer = writer;
+        this.separator = ",";
+    }
+
+    public <T> void write(Stream<T> records, Function<T, Stream<String>> rowFunction) {
+        List<String> rows =
+                records
+                        .map(record -> mapToRow(rowFunction, record))
+                        .collect(Collectors.toList());
+
+        writeRow(joinFields(header.stream()));
+        rows.forEach(this::writeRow);
+    }
+
+    @Override
+    public void close() {
+        try {
+            writer.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    private <T> String mapToRow(Function<T, Stream<String>> rowFunction, T record) {
+        Stream<String> fields = rowFunction.apply(record);
+        return joinFields(fields);
+    }
+
+    private String joinFields(Stream<String> fields) {
+        return fields
+                .map(field -> "\"" + field.replace("\"", "\"\"") + "\"")
+                .collect(joining(separator));
+    }
+
+    private void writeRow(String row) {
+        try {
+            writer.write(row + "\n");
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+}

--- a/processor/src/main/java/net/biville/florent/sproccompiler/visitors/ExecutableElementVisitor.java
+++ b/processor/src/main/java/net/biville/florent/sproccompiler/visitors/ExecutableElementVisitor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.biville.florent.sproccompiler.visitors;
+
+import javax.annotation.processing.Messager;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementVisitor;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.util.SimpleElementVisitor8;
+import javax.tools.Diagnostic;
+
+public class ExecutableElementVisitor extends SimpleElementVisitor8<ExecutableElement, Void> {
+    private final Messager messager;
+
+    public ExecutableElementVisitor(Messager messager) {
+        this.messager = messager;
+    }
+
+    @Override
+    public ExecutableElement visitExecutable(ExecutableElement method, Void ignored) {
+        return method;
+    }
+
+    @Override
+    public ExecutableElement visitUnknown(Element e, Void aVoid) {
+        messager.printMessage(Diagnostic.Kind.ERROR, "Unexpected @Procedure|@UserFunction on element", e);
+        return null;
+    }
+}

--- a/processor/src/test/java/net/biville/florent/sproccompiler/CsvProcessorTest.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/CsvProcessorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.biville.florent.sproccompiler;
+
+import com.google.testing.compile.CompilationRule;
+import net.biville.florent.sproccompiler.testutils.JavaFileObjectUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.annotation.processing.Processor;
+import javax.tools.JavaFileObject;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Collectors;
+
+import static com.google.common.truth.Truth.assert_;
+import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
+import static java.nio.file.Files.readAllLines;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CsvProcessorTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @Rule
+    public CompilationRule compilation = new CompilationRule();
+    private Processor processor = new CsvProcessor();
+    private File folder;
+
+
+    @Before
+    public void prepare() throws IOException {
+        folder = temporaryFolder.newFolder();
+    }
+
+    @Test
+    public void dumps_procedure_definition_to_csv() throws IOException {
+        Iterable<JavaFileObject> sources = asList(
+                JavaFileObjectUtils.INSTANCE.procedureSource("valid/SimpleProcedures.java"),
+                JavaFileObjectUtils.INSTANCE.procedureSource("valid/SimpleUserFunctions.java"));
+
+        assert_().about( javaSources() ).that(sources)
+                .withCompilerOptions("-AGeneratedDocumentationPath=" + folder.getAbsolutePath())
+                .processedWith(processor)
+                .compilesWithoutError();
+
+        String namespace = "net.biville.florent.sproccompiler.procedures.valid.";
+        String generatedCsv = readContents(Paths.get(folder.getAbsolutePath(), "valid.csv"));
+        assertThat(generatedCsv).isEqualTo("" +
+                "\"name\",\"description\",\"execution mode\",\"location\",\"deprecated by\"\n" +
+                "\"" + namespace + "doSomething(int foo)\",\"\",\"PERFORMS_WRITE\",\"" + namespace + "SimpleProcedures\",\"doSomething2\"\n" +
+                "\"" + namespace + "doSomething2(long bar)\",\"Much better than the former version\",\"SCHEMA\",\"" + namespace + "SimpleProcedures\",\"N/A\"\n" +
+                "\"" + namespace + "sum(int a,int b)\",\"Performs super complex maths\",\"N/A\",\"" + namespace + "SimpleUserFunctions\",\"N/A\"");
+
+    }
+
+    private String readContents(Path path) throws IOException {
+        return readAllLines(path)
+                .stream()
+                .collect(Collectors.joining("\n"));
+    }
+}

--- a/processor/src/test/java/net/biville/florent/sproccompiler/io/CsvWriterTest.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/io/CsvWriterTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.biville.florent.sproccompiler.io;
+
+import org.junit.Test;
+
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CsvWriterTest {
+
+    @Test
+    public void writes_csv_records() {
+        StringWriter writer = new StringWriter();
+        try (CsvWriter csvWriter = new CsvWriter(Arrays.asList("first header", "second header"), writer)) {
+            csvWriter.write(Stream.of("haha_this is", "so much_fun"), (row) -> Arrays.stream(row.split("_")));
+            String result = writer.toString();
+            assertThat(result).isEqualTo(
+                    "\"first header\",\"second header\"\n" +
+                    "\"haha\",\"this is\"\n" +
+                    "\"so much\",\"fun\"\n" );
+        }
+    }
+}

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/valid/SimpleProcedures.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/valid/SimpleProcedures.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.biville.florent.sproccompiler.procedures.valid;
+
+import org.neo4j.procedure.*;
+
+public class SimpleProcedures {
+
+    @Procedure(deprecatedBy = "doSomething2")
+    @PerformsWrites
+    public void doSomething(@Name("foo") int foo) {
+
+    }
+
+    @Procedure(mode = Mode.SCHEMA)
+    @Description("Much better than the former version")
+    public void doSomething2(@Name("bar") long bar) {
+
+    }
+}

--- a/processor/src/test/java/net/biville/florent/sproccompiler/procedures/valid/SimpleUserFunctions.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/procedures/valid/SimpleUserFunctions.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.biville.florent.sproccompiler.procedures.valid;
+
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.UserFunction;
+
+public class SimpleUserFunctions {
+
+    @UserFunction
+    @Description("Performs super complex maths")
+    public long sum(@Name("a") int operand1, @Name("b") int operand2) {
+        return operand1+operand2;
+    }
+}


### PR DESCRIPTION
It is enabled with a simple processor option
`-AGeneratedDocumentationPath` which points to the location of the
generated CSVs.

1 CSV is generated per package, to keep things simple.

This solves neo4j-contrib/neo4j-apoc-procedures/issues/71.