### PR TITLE
Explicitly reject all invalid types

### DIFF
--- a/processor/src/main/java/net/biville/florent/sproccompiler/compilerutils/TypeMirrorUtils.java
+++ b/processor/src/main/java/net/biville/florent/sproccompiler/compilerutils/TypeMirrorUtils.java
@@ -60,6 +60,20 @@ public class TypeMirrorUtils
 
     public TypeMirror typeMirror( Class<?> type )
     {
+        if ( type == void.class )
+        {
+            return typeUtils.getNoType( TypeKind.VOID );
+        }
+        if ( type.isPrimitive() )
+        {
+            TypeKind primitiveKind = TypeKind.valueOf( type.getName().toUpperCase() );
+            return typeUtils.getPrimitiveType( primitiveKind );
+        }
+        if ( type.isArray() )
+        {
+            TypeMirror componentType = typeMirror( type.getComponentType() );
+            return typeUtils.getArrayType( componentType );
+        }
         return elementUtils.getTypeElement( type.getName() ).asType();
     }
 

--- a/processor/src/main/java/net/biville/florent/sproccompiler/visitors/ParameterTypeVisitor.java
+++ b/processor/src/main/java/net/biville/florent/sproccompiler/visitors/ParameterTypeVisitor.java
@@ -32,6 +32,7 @@ class ParameterTypeVisitor extends SimpleTypeVisitor8<Boolean,Void>
 
     public ParameterTypeVisitor( Types typeUtils, TypeMirrorUtils typeMirrors )
     {
+        super( Boolean.FALSE );
         allowedTypesValidator = new AllowedTypesValidator( typeMirrors, typeUtils );
     }
 

--- a/processor/src/main/java/net/biville/florent/sproccompiler/visitors/RecordFieldTypeVisitor.java
+++ b/processor/src/main/java/net/biville/florent/sproccompiler/visitors/RecordFieldTypeVisitor.java
@@ -32,6 +32,7 @@ class RecordFieldTypeVisitor extends SimpleTypeVisitor8<Boolean,Void>
 
     public RecordFieldTypeVisitor( Types typeUtils, TypeMirrorUtils typeMirrors )
     {
+        super( Boolean.FALSE );
         allowedTypesValidator = new AllowedTypesValidator( typeMirrors, typeUtils );
     }
 

--- a/processor/src/test/java/net/biville/florent/sproccompiler/visitors/TypeValidationTestSuite.java
+++ b/processor/src/test/java/net/biville/florent/sproccompiler/visitors/TypeValidationTestSuite.java
@@ -94,6 +94,9 @@ abstract class TypeValidationTestSuite
                 .isFalse();
         assertThat( visitor().visit( typeMirrorTestUtils()
                 .typeOf( List.class, typeMirrorTestUtils().typeOf( List.class, CharSequence.class ) ) ) ).isFalse();
+        assertThat( visitor().visit( typeMirrorTestUtils().typeOf( int[].class ) ) ).isFalse();
+        assertThat( visitor().visit( typeMirrorTestUtils().typeOf( long[].class ) ) ).isFalse();
+        assertThat( visitor().visit( typeMirrorTestUtils().typeOf( void.class ) ) ).isFalse();
     }
 
     protected abstract TypeVisitor<Boolean,Void> visitor();


### PR DESCRIPTION
The default behavior of the Simple*Visitors is to return null for any
case that has not been overridden.
When, for example, a procedure return type defines a field with
an array type, the RecordFieldTypeVisitor returns `null` instead of
`false`, leading to an unhelpful `NullPointerException` in
https://github.com/fbiville/neo4j-sproc-compiler/blob/34a718cc6793a2c96732cdc14ccf22d7f0652b4d/processor/src/main/java/net/biville/florent/sproccompiler/visitors/RecordTypeVisitor.java#L74
instead of the more helpful error message that the
target type is not supported.

With this commit, the validating visitors explicitly return `false`
instead of `null` on types that aren't covered directly.